### PR TITLE
Finalize Craft 4 support and release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0 - 2026-06-12
+
+> Stable Craft 4 release.
+
+### Fixed
+- Calling `readTime` on an entry containing Matrix or Super Table fields no longer throws a Twig error on Craft 4. The deprecated `FieldLayout::getFields()` calls in the nested Matrix, Super Table, and Matrix-in-Super-Table loops are now `getCustomFields()` ([#25](https://github.com/jalendport/craft-readtime/issues/25)).
+- Widened the exception handling in `readTimeFunction()` to also catch `craft\errors\InvalidFieldException` (thrown by `getFieldValue()`), which previously could surface as an uncaught Twig error.
+
 ## 2.0.0-beta.1 - 2023-03-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jalendport/craft-readtime",
     "description": "Calculate the estimated read time for content.",
     "type": "craft-plugin",
-    "version": "2.0.0-beta.1",
+    "version": "2.0.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/twigextensions/ReadTimeTwigExtension.php
+++ b/src/twigextensions/ReadTimeTwigExtension.php
@@ -49,9 +49,6 @@ class ReadTimeTwigExtension extends AbstractExtension
         ];
     }
 
-	/**
-	 * @throws InvalidFieldException
-	 */
 	public function readTimeFunction($element, $showSeconds = true): TimeModel
 	{
         $totalSeconds = 0;
@@ -64,7 +61,7 @@ class ReadTimeTwigExtension extends AbstractExtension
                     // If field is a matrix then loop through fields in block
                     if ($field instanceof Matrix) {
                         foreach($element->getFieldValue($field->handle)->all() as $block) {
-                            $blockFields = $block->getFieldLayout()->getFields();
+                            $blockFields = $block->getFieldLayout()->getCustomFields();
 
                             foreach ($blockFields as $blockField) {
                                 $value = $block->getFieldValue($blockField->handle);
@@ -74,12 +71,12 @@ class ReadTimeTwigExtension extends AbstractExtension
                         }
                     } elseif($field instanceof SuperTableField) {
                         foreach($element->getFieldValue($field->handle)->all() as $block) {
-                            $blockFields = $block->getFieldLayout()->getFields();
+                            $blockFields = $block->getFieldLayout()->getCustomFields();
 
                             foreach ($blockFields as $blockField) {
                                 if ($blockField instanceof Matrix) {
                                     foreach($block->getFieldValue($blockField->handle)->all() as $matrix) {
-                                        $matrixFields = $matrix->getFieldLayout()->getFields();
+                                        $matrixFields = $matrix->getFieldLayout()->getCustomFields();
 
                                         foreach ($matrixFields as $matrixField) {
                                             $value = $matrix->getFieldValue($matrixField->handle);
@@ -99,7 +96,7 @@ class ReadTimeTwigExtension extends AbstractExtension
                         $seconds = $this->valToSeconds($value);
                         $totalSeconds = $totalSeconds + $seconds;
                     }
-                } catch (ErrorException $e) {
+                } catch (ErrorException | InvalidFieldException $e) {
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

Finalizes Craft 4 support and prepares the stable **v2.0.0** release.

Closes #25. Incorporates the fix from #27 (rebased onto `develop`) plus a Craft 4 correctness audit.

### Changes

**1. Deprecated `getFields()` → `getCustomFields()`** (the #25 fix)
Replaces the 3 remaining deprecated `FieldLayout::getFields()` calls in `src/twigextensions/ReadTimeTwigExtension.php`:
- the nested Matrix block loop,
- the Super Table block loop,
- the Matrix-in-Super-Table loop.

`getFields()` was removed from `craft\models\FieldLayout` in Craft 4, so calling `readTime` on an entry containing Matrix/Super Table fields threw a Twig error. The top-level entry loop and the `MatrixBlock` array branch already used `getCustomFields()`; these were the only 3 remaining deprecated calls (verified by grepping all of `src/`).

**2. Widened the exception handling in `readTimeFunction()`**
`Element::getFieldValue()` throws `craft\errors\InvalidFieldException`, which extends `yii\base\Exception` — **not** `yii\base\ErrorException`. The previous `catch (ErrorException $e)` therefore could not catch it, so an `InvalidFieldException` would leak out as an uncaught Twig error. The catch is now `catch (ErrorException | InvalidFieldException $e)`. The now-redundant `@throws InvalidFieldException` docblock was removed since the exception is handled internally.

**3. v2.0.0 release prep**
- `composer.json` version `2.0.0-beta.1` → `2.0.0`.
- Dated `## 2.0.0` entry added to `CHANGELOG.md`.

### Craft 4 audit notes

- **Full `src/` grep** confirms no remaining deprecated/removed Craft 4 API calls after this change. `ReadTime.php`, `models/Settings.php`, and `models/TimeModel.php` use only valid Craft 4 APIs (`registerTwigExtension`, `DateTimeHelper::humanDuration/currentTimeStamp/toDateTime`, etc.). `init()` without a return type is compatible with Yii/Craft's untyped `init()`.
- **Super Table soft-dependency:** `verbb\supertable\fields\SuperTableField` is referenced only via a `use` alias and `instanceof`. A `use` statement does not autoload or fail for a missing class, and `instanceof` against an undefined class returns `false` without fataling. So the plugin loads and computes read time on a Craft 4 site **without** Super Table installed. No code change needed.

### Scope

Craft 4 only (`craftcms/cms: ^4.0.0`). No Craft 5 modernization — `MatrixBlock` and the current Matrix block model are preserved. No new features.

### Verification

No PHP/Composer toolchain is available in this environment, so changes were verified by manual review: the edits are a method-name swap, a union catch type (valid PHP 7.1+; Craft 4 requires PHP 8.0.2+), a docblock removal, and metadata. Both catch classes (`ErrorException`, `InvalidFieldException`) are already imported. The repo has no CI workflows configured, so there are no automated checks to run.
