### PR TITLE
Add Redactor field support (Craft 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.2.0 - 2026-06-12
+
+### Added
+- Redactor field support. `readTime` now counts content stored in [Redactor](https://github.com/craftcms/redactor) rich-text fields toward the calculated read time, both when a Redactor field sits directly on an entry and when it is nested inside Matrix, Neo, or Super Table blocks. Redactor stores its value as HTML, so the markup is now stripped before counting and the word count reflects the readable text rather than the tags. Redactor is treated as an optional, soft dependency — the plugin continues to load and compute read time on sites without Redactor installed.
+
 ## 2.1.0 - 2026-06-12
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "jalendport/craft-readtime",
     "description": "Calculate the estimated read time for content.",
     "type": "craft-plugin",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "keywords": [
         "craft",
         "cms",

--- a/src/twigextensions/ReadTimeTwigExtension.php
+++ b/src/twigextensions/ReadTimeTwigExtension.php
@@ -149,6 +149,16 @@ class ReadTimeTwigExtension extends AbstractExtension
         $wpm = $settings->wordsPerMinute;
 
         $string = StringHelper::toString($value);
+
+        // Rich-text fields such as Redactor stringify to raw HTML. Strip the
+        // markup before counting so tags and attributes aren't counted as
+        // words. Only strip when a complete tag is present, so plain-text
+        // values (which may legitimately contain a stray "<") are untouched.
+        // Tags are replaced with a space first so adjacent words don't merge.
+        if (preg_match('/<[^>]+>/', $string)) {
+            $string = strip_tags(preg_replace('/<[^>]+>/', ' ', $string));
+        }
+
         $wordCount = StringHelper::countWords($string);
         $seconds = floor($wordCount / $wpm * 60);
 


### PR DESCRIPTION
## Summary

Adds Redactor rich-text field support to the Craft 4 line so Redactor content contributes to the calculated read time.

Redactor stores its value as HTML, so when a field value is stringified for word counting it previously included tags and attributes, which skewed the count. This change strips HTML from the value before counting words.

## Approach

The strip happens inside `valToSeconds()` in `src/twigextensions/ReadTimeTwigExtension.php`. Every leaf field value already flows through that method, so this single change covers all call sites at once:

- a Redactor field directly on an entry,
- a Redactor field nested inside Matrix, Neo, and Super Table blocks (including Matrix-in-Super-Table).

Tags are only stripped when the string actually contains a complete `<...>` tag, and each tag is replaced with a space first so adjacent words don't merge. Plain-text values that contain a stray `<` are left untouched, so existing behaviour for non-HTML fields is unchanged.

## Soft dependency

No reference to Redactor's field class is added, so the plugin loads and computes read time normally on a Craft 4 site that does not have Redactor installed — no `class_exists` guard or `instanceof` is required and there is no fatal-error risk. This satisfies the soft/optional dependency requirement by construction.

## Other changes

- `CHANGELOG.md`: dated `2.2.0` entry describing Redactor support.
- `composer.json`: version bumped `2.1.0` → `2.2.0`.

## Verification

No formal CI on this maintenance line. PHP was not available in the environment to run `php -l`; the added lines use only PHP core functions (`preg_match`, `preg_replace`, `strip_tags`) and were reviewed manually for syntax. The diff is scoped to Redactor support only.

Relates to JAL-106.
