### PR TITLE
Add configurable minimum read time setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## Unreleased
 
 ### Added
-- A `minimumReadTime` setting (in whole minutes). When greater than `0`, read times are rounded up to at least this many minutes, so sub-minute and empty content displays as e.g. "1 minute" instead of "less than a minute". Defaults to `0`, which preserves the existing behaviour. The floor is applied once when the service builds the `TimeModel`, so it is reflected consistently across `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`, the Twig function and filter, and the GraphQL `readTime` field. Can be set in `config/read-time.php` ([#26](https://github.com/jalendport/craft-readtime/issues/26)).
+- A `minimumReadTime` setting (in whole minutes). When greater than `0`, read times are rounded up to at least this many minutes, so sub-minute and empty content displays as e.g. "1 minute" instead of "less than a minute". Defaults to `0`, which preserves the existing behaviour. The floor is applied once when the service builds the `TimeModel`, so it is reflected consistently across `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`, the Twig function, and the Twig filter — and any other consumer of the returned `TimeModel`. Can be set in `config/read-time.php` ([#26](https://github.com/jalendport/craft-readtime/issues/26)).
 
 ### Fixed
 - The settings template referenced the wrong config filename (`reading-time.php`) and translation category (`reading-time`); both are now `read-time`, so the config-override warning points at the correct file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- A `minimumReadTime` setting (in whole minutes). When greater than `0`, read times are rounded up to at least this many minutes, so sub-minute and empty content displays as e.g. "1 minute" instead of "less than a minute". Defaults to `0`, which preserves the existing behaviour. The floor is applied once when the service builds the `TimeModel`, so it is reflected consistently across `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`, the Twig function and filter, and the GraphQL `readTime` field. Can be set in `config/read-time.php` ([#26](https://github.com/jalendport/craft-readtime/issues/26)).
+
+### Fixed
+- The settings template referenced the wrong config filename (`reading-time.php`) and translation category (`reading-time`); both are now `read-time`, so the config-override warning points at the correct file.
+
 ## 3.0.0 - 2026-06-12
 
 > Craft 5 release. The 2.x line remains the Craft 4 line.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,18 @@ You can also format the duration as a [`DateInterval`](https://www.php.net/manua
 {{ time.interval('%h hours, %i minutes, %s seconds') }}  {# 0 hours, 2 minutes, 40 seconds #}
 ```
 
+### Settings
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `wordsPerMinute` | `200` | The average reading speed, in words per minute, used to calculate the read time. |
+| `minimumReadTime` | `0` | Minimum read time, in whole minutes. When greater than `0`, read times are rounded **up** to at least this many minutes, so sub-minute (and empty) content displays as e.g. "1 minute" instead of "less than a minute". `0` keeps the default behaviour. |
+
+The minimum is applied at the source, so it is reflected consistently everywhere — `time.human`, `time.seconds`, `time.minutes`, `time.hours`, the `readTime()` function, the `|readTime` filter, and the GraphQL `readTime` field all agree.
+
 ### Overriding Plugin Settings
 
-The average user read speed is set at 200 words per minute by default. This can be changed in the plugin settings, or overridden with a config file.
+Both settings can be changed in the plugin settings in the Control Panel, or overridden with a config file.
 
 If you create a [config file](https://craftcms.com/docs/5.x/configure.html#config-files) in your `config` folder called `read-time.php`, you can override the plugin's settings in the Control Panel. Since that config file is fully [multi-environment](https://craftcms.com/docs/5.x/configure.html#multi-environment-configs) aware, this is a handy way to have different settings across multiple environments. An example is included at [`config/read-time.php`](config/read-time.php).
 
@@ -117,6 +126,7 @@ If you create a [config file](https://craftcms.com/docs/5.x/configure.html#confi
 
 return [
     'wordsPerMinute' => 200,
+    'minimumReadTime' => 0,
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can also format the duration as a [`DateInterval`](https://www.php.net/manua
 | `wordsPerMinute` | `200` | The average reading speed, in words per minute, used to calculate the read time. |
 | `minimumReadTime` | `0` | Minimum read time, in whole minutes. When greater than `0`, read times are rounded **up** to at least this many minutes, so sub-minute (and empty) content displays as e.g. "1 minute" instead of "less than a minute". `0` keeps the default behaviour. |
 
-The minimum is applied at the source, so it is reflected consistently everywhere — `time.human`, `time.seconds`, `time.minutes`, `time.hours`, the `readTime()` function, the `|readTime` filter, and the GraphQL `readTime` field all agree.
+The minimum is applied at the source, so it is reflected consistently everywhere — `time.human`, `time.seconds`, `time.minutes`, `time.hours`, the `readTime()` function, and the `|readTime` filter all agree, as does any other consumer of the returned `TimeModel`.
 
 ### Overriding Plugin Settings
 

--- a/config/read-time.php
+++ b/config/read-time.php
@@ -12,4 +12,10 @@
 return [
     // The average reading speed, in words per minute.
     'wordsPerMinute' => 200,
+
+    // Minimum read time, in whole minutes. When greater than 0, read times are
+    // rounded up to at least this many minutes, so sub-minute content displays
+    // as e.g. "1 minute" instead of "less than a minute". 0 keeps the default
+    // behaviour.
+    'minimumReadTime' => 0,
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -21,11 +21,19 @@ class Settings extends Model
      */
     public int $wordsPerMinute = 200;
 
+    /**
+     * @var int Minimum read time, in whole minutes. When greater than 0, read
+     * times are rounded up to at least this many minutes. 0 (the default)
+     * preserves Craft's "less than a minute" output for sub-minute content.
+     */
+    public int $minimumReadTime = 0;
+
     public function rules(): array
     {
         return [
             [['wordsPerMinute'], 'required'],
             [['wordsPerMinute'], 'number', 'integerOnly' => true],
+            [['minimumReadTime'], 'number', 'integerOnly' => true, 'min' => 0],
         ];
     }
 }

--- a/src/services/ReadTime.php
+++ b/src/services/ReadTime.php
@@ -161,7 +161,8 @@ class ReadTime extends Component
      * Builds a {@see TimeModel} from a raw second count, applying the configured
      * minimum read time. This is the single place the floor is enforced, so every
      * output path — `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`,
-     * the Twig function and filter, and the GraphQL `readTime` field — agrees.
+     * the Twig function and filter, and every other consumer of the returned
+     * `TimeModel` — agrees.
      */
     private function makeTimeModel(int $seconds, bool $showSeconds): TimeModel
     {

--- a/src/services/ReadTime.php
+++ b/src/services/ReadTime.php
@@ -64,10 +64,7 @@ class ReadTime extends Component
      */
     public function calculateForElement(mixed $element, bool $showSeconds = true): TimeModel
     {
-        return new TimeModel([
-            'seconds' => $this->secondsForValue($element),
-            'showSeconds' => $showSeconds,
-        ]);
+        return $this->makeTimeModel($this->secondsForValue($element), $showSeconds);
     }
 
     /**
@@ -76,10 +73,7 @@ class ReadTime extends Component
      */
     public function calculateForValue(mixed $value, bool $showSeconds = true): TimeModel
     {
-        return new TimeModel([
-            'seconds' => $this->secondsForString($value),
-            'showSeconds' => $showSeconds,
-        ]);
+        return $this->makeTimeModel($this->secondsForString($value), $showSeconds);
     }
 
     /**
@@ -162,6 +156,33 @@ class ReadTime extends Component
 
     // Private Methods
     // =========================================================================
+
+    /**
+     * Builds a {@see TimeModel} from a raw second count, applying the configured
+     * minimum read time. This is the single place the floor is enforced, so every
+     * output path — `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`,
+     * the Twig function and filter, and the GraphQL `readTime` field — agrees.
+     */
+    private function makeTimeModel(int $seconds, bool $showSeconds): TimeModel
+    {
+        $minimum = $this->getMinimumReadTime();
+
+        if ($minimum > 0) {
+            $seconds = max($seconds, $minimum * 60);
+        }
+
+        return new TimeModel([
+            'seconds' => $seconds,
+            'showSeconds' => $showSeconds,
+        ]);
+    }
+
+    private function getMinimumReadTime(): int
+    {
+        $minimum = ReadTimePlugin::getInstance()->getSettings()->minimumReadTime;
+
+        return $minimum > 0 ? $minimum : 0;
+    }
 
     private function secondsForValue(mixed $element): int
     {

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -2,9 +2,9 @@
 
 {% macro configWarning(setting) -%}
   {% set setting = '<code>' ~ setting ~ '</code>' %}
-  {{ 'This is being overridden by the {setting} config setting in your {file} config file.'|t('reading-time', {
+  {{ 'This is being overridden by the {setting} config setting in your {file} config file.'|t('read-time', {
         setting: setting,
-        file:    'reading-time.php'
+        file:    'read-time.php'
   })|raw }}
 {%- endmacro %}
 
@@ -21,4 +21,15 @@
     value:        settings.wordsPerMinute,
     disabled:     'wordsPerMinute' in overrides,
     warning:      'wordsPerMinute' in overrides ? configWarning('wordsPerMinute'),
+}) }}
+
+{{ forms.textField({
+    label:        'Minimum Read Time',
+    instructions: 'Round read times up to at least this many minutes. Leave at 0 to keep the default "less than a minute" output for very short content.',
+    placeholder:  '0',
+    id:           'minimumReadTime',
+    name:         'minimumReadTime',
+    value:        settings.minimumReadTime,
+    disabled:     'minimumReadTime' in overrides,
+    warning:      'minimumReadTime' in overrides ? configWarning('minimumReadTime'),
 }) }}


### PR DESCRIPTION
## Summary

Adds a configurable **minimum read time** so very short content no longer shows Craft's "less than a minute" output. Closes #26.

When `minimumReadTime > 0`, the total read time (in seconds) is floored to `minimumReadTime * 60` so sub-minute — and genuinely empty — content rounds **up** to at least the configured number of minutes (e.g. "1 minute"). Default is `0`, which preserves today's exact behavior; the feature is strictly opt-in.

## Changes

- **`src/models/Settings.php`** — new `public int $minimumReadTime = 0;` with a validation rule (`integer`, `min => 0`).
- **`src/services/ReadTime.php`** — the floor is applied in a single private factory, `makeTimeModel(int $seconds, bool $showSeconds)`, which both `calculateForElement()` (function path) and `calculateForValue()` (filter path) now call. Applying it once at the source means every output path agrees — `human()`, `__toString()`, `seconds()`/`minutes()`/`hours()`, the Twig function, and the Twig filter — and any other consumer of the returned `TimeModel`. `TimeModel` stays a plain value object with no settings access.
- **`src/templates/settings.twig`** — adds a "Minimum Read Time" field below "Words per Minute" with config-file override support (auto-disable + override warning). Also fixes a pre-existing bug: the template referenced `reading-time.php` / the `reading-time` translation category, but the plugin handle is `read-time` (so the real config file is `config/read-time.php`); both are now `read-time` so the override warning points at the correct file.
- **`config/read-time.php`**, **`README.md`**, **`CHANGELOG.md`** — document the new setting; changelog entry recorded under `## Unreleased`. `composer.json` version is intentionally unchanged.

## Behavior

| `minimumReadTime` | sub-minute / empty content |
| --- | --- |
| `0` (default) | unchanged — "less than a minute" |
| `1` | floored to 60s → `minutes()` returns `1`, displays "1 minute" |

## Verification

This repo has no PHP toolchain or test harness in the workspace (no `tests/`, no `require-dev`, no test CI), so I verified by tracing the logic against the acceptance criteria rather than executing:

- `minimumReadTime = 0` → the `if ($minimum > 0)` guard skips the clamp, so output is byte-for-byte the current behavior (no regression).
- `minimumReadTime = 1`, empty/sub-minute content → `max($seconds, 60) = 60` → `minutes() = floor(60/60) = 1`, `human()` = "1 minute", and every other accessor reads from the same floored `seconds`.
- The clamp lives only in the service factory; `TimeModel` is untouched, so every consumer of it (Twig function, filter, and all accessors) cannot disagree. This v3 rewrite registers no GraphQL type; because the floor is built into the `TimeModel` at the source, any GraphQL exposure added later inherits it automatically.

A QA pass in a real Craft 5 install (settings UI render, config-override warning) would be a good follow-up — I can't run a CP browser session from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

