### PR TITLE
Strip HTML before counting words

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [develop, master]
+
+jobs:
+  test:
+    name: Pest (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom, bcmath, intl, gd, zip, curl, pdo, pdo_mysql, fileinfo, openssl
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          restore-keys: composer-${{ matrix.php }}-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run test suite
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 /vendor
 composer.lock
+/.phpunit.cache
+/.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- HTML markup is now stripped before content is word-counted, so read-time estimates are no longer inflated by tag names, attribute names, and attribute values such as URLs ([#14](https://github.com/jalendport/craft-readtime/issues/14)). The fix is applied centrally in the word counter, so both the `readTime` filter (raw strings) and `readTime()` (field-walking over rich-text fields like CKEditor) are corrected. Tags are replaced with whitespace (not removed) so words across tag boundaries stay separate, and HTML entities are decoded so `&nbsp;` counts as whitespace and `&amp;` isn't counted as a word. Plain (non-HTML) text counts are unchanged.
+
 ## 3.0.0 - 2026-06-12
 
 > Craft 5 release. The 2.x line remains the Craft 4 line.

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "php": "^8.2",
         "craftcms/cms": "^5.0.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5"
+    },
     "suggest": {
         "spicyweb/craft-neo": "Adds read time support for content stored in Neo fields.",
         "verbb/vizy": "Adds read time support for content stored in Vizy fields.",
@@ -38,6 +41,14 @@
         "psr-4": {
           "jalendport\\readtime\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+          "jalendport\\readtime\\tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     },
     "extra": {
         "name": "Read Time",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "craftcms/cms": "^5.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "pestphp/pest": "^3.0"
     },
     "suggest": {
         "spicyweb/craft-neo": "Adds read time support for content stored in Neo fields.",
@@ -47,8 +47,15 @@
           "jalendport\\readtime\\tests\\": "tests/"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
+    },
     "scripts": {
-        "test": "phpunit"
+        "test": "pest"
     },
     "extra": {
         "name": "Read Time",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/services/ReadTime.php
+++ b/src/services/ReadTime.php
@@ -200,7 +200,38 @@ class ReadTime extends Component
 
     private function countWords(mixed $value): int
     {
-        return StringHelper::countWords(StringHelper::toString($value));
+        return StringHelper::countWords($this->htmlToText(StringHelper::toString($value)));
+    }
+
+    /**
+     * Cleans a (possibly HTML) string so markup doesn't inflate its word count.
+     * Rich-text fields (CKEditor, Vizy, etc.) and raw strings passed to the
+     * `readTime` Twig filter both route through here via {@see countWords()},
+     * so the fix applies to every counting path.
+     *
+     * Behaviour:
+     * - HTML tags are replaced with a single space (not removed) so words on
+     *   either side of a tag boundary stay separate — `<p>foo</p><p>bar</p>`
+     *   counts as two words, not one. Removing tags outright would merge them.
+     * - HTML entities are decoded *after* tags are stripped, so text that is
+     *   legitimately encoded as `&lt;`/`&gt;` isn't mistaken for a tag and
+     *   over-stripped. Decoding also keeps entities like `&amp;` from being
+     *   counted as words and turns `&nbsp;` into whitespace.
+     * - Runs of whitespace are collapsed, including the spaces introduced above
+     *   and Unicode whitespace such as the non-breaking space (U+00A0) produced
+     *   by `&nbsp;`. The `(*UCP)` verb makes `\s` match Unicode whitespace.
+     *
+     * Plain (non-HTML) text has no tags or entities, so it passes through
+     * unchanged apart from whitespace trimming, leaving its word count intact.
+     */
+    private function htmlToText(string $text): string
+    {
+        // Order matters: strip tags first, then decode entities.
+        $text = preg_replace('/<[^>]+>/', ' ', $text) ?? $text;
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5);
+        $text = preg_replace('/(*UCP)\s+/u', ' ', $text) ?? $text;
+
+        return trim($text);
     }
 
     private function wordsToSeconds(int $words): int

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Read Time plugin for Craft CMS 5.x
+ *
+ * @link      https://github.com/jalendport
+ * @copyright Copyright (c) 2018 Jalen Davenport
+ */
+
+declare(strict_types=1);
+
+use jalendport\readtime\services\ReadTime;
+
+/*
+|--------------------------------------------------------------------------
+| Helpers
+|--------------------------------------------------------------------------
+|
+| The counting helpers on the ReadTime service are private, so they're
+| exercised through reflection. `htmlToText()` is pure string-cleaning (no
+| Craft application needed) and `countWords()` only delegates to
+| `craft\helpers\StringHelper`, so neither requires a booted Craft instance.
+*/
+
+function htmlToText(string $text): string
+{
+    $method = new ReflectionMethod(ReadTime::class, 'htmlToText');
+    $method->setAccessible(true);
+
+    return $method->invoke(new ReadTime(), $text);
+}
+
+function countWords(mixed $value): int
+{
+    $method = new ReflectionMethod(ReadTime::class, 'countWords');
+    $method->setAccessible(true);
+
+    return $method->invoke(new ReadTime(), $value);
+}

--- a/tests/unit/ReadTimeHtmlStrippingTest.php
+++ b/tests/unit/ReadTimeHtmlStrippingTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Read Time plugin for Craft CMS 5.x
+ *
+ * @link      https://github.com/jalendport
+ * @copyright Copyright (c) 2018 Jalen Davenport
+ */
+
+declare(strict_types=1);
+
+namespace jalendport\readtime\tests\unit;
+
+use jalendport\readtime\services\ReadTime;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit coverage for the HTML-stripping behaviour added to the word counter.
+ *
+ * The counting helpers are private, so they're exercised through reflection.
+ * `htmlToText()` is pure string-cleaning (no Craft application needed), and
+ * `countWords()` only delegates to `craft\helpers\StringHelper`, so neither
+ * requires a booted Craft instance.
+ */
+final class ReadTimeHtmlStrippingTest extends TestCase
+{
+    private ReadTime $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ReadTime();
+    }
+
+    private function htmlToText(string $text): string
+    {
+        $method = new ReflectionMethod(ReadTime::class, 'htmlToText');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->service, $text);
+    }
+
+    private function countWords(mixed $value): int
+    {
+        $method = new ReflectionMethod(ReadTime::class, 'countWords');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->service, $value);
+    }
+
+    /**
+     * Tags are replaced with whitespace, not removed, so words on either side of
+     * a tag boundary are not merged.
+     */
+    public function testTagsBecomeWhitespaceAndDoNotMergeWords(): void
+    {
+        self::assertSame('foo bar', $this->htmlToText('<p>foo</p><p>bar</p>'));
+        self::assertSame(2, $this->countWords('<p>foo</p><p>bar</p>'));
+    }
+
+    /**
+     * Tag names, attribute names and attribute values (such as URLs) are all
+     * excluded from the cleaned text.
+     */
+    public function testTagAndAttributeTextIsExcluded(): void
+    {
+        $html = '<a class="link" href="https://example.com/some/page">Read more</a>';
+
+        self::assertSame('Read more', $this->htmlToText($html));
+        self::assertSame(2, $this->countWords($html));
+    }
+
+    /**
+     * Nested inline markup is stripped without dropping content.
+     */
+    public function testNestedInlineMarkupIsStripped(): void
+    {
+        $html = '<p>Hello <strong>brave</strong> <em>new</em> world</p>';
+
+        self::assertSame('Hello brave new world', $this->htmlToText($html));
+        self::assertSame(4, $this->countWords($html));
+    }
+
+    /**
+     * Entities are decoded after tags are stripped: `&amp;` becomes a literal
+     * `&` rather than being counted as a word.
+     */
+    public function testHtmlEntitiesAreDecoded(): void
+    {
+        self::assertSame('Salt & Pepper', $this->htmlToText('Salt &amp; Pepper'));
+    }
+
+    /**
+     * `&nbsp;` decodes to a non-breaking space and is treated as whitespace, so
+     * the words it separates are counted independently.
+     */
+    public function testNonBreakingSpaceIsTreatedAsWhitespace(): void
+    {
+        self::assertSame('foo bar', $this->htmlToText('foo&nbsp;bar'));
+        self::assertSame(2, $this->countWords('foo&nbsp;bar'));
+    }
+
+    /**
+     * Tags are stripped before entities are decoded, so text legitimately
+     * encoded as `&lt;`/`&gt;` is preserved rather than mistaken for a tag.
+     */
+    public function testEncodedAnglesAreNotTreatedAsTags(): void
+    {
+        self::assertSame('a <b> c', $this->htmlToText('a &lt;b&gt; c'));
+    }
+
+    /**
+     * Plain (non-HTML) text is unchanged apart from whitespace normalisation, so
+     * its word count is unaffected by the stripping.
+     */
+    public function testPlainTextIsUnchanged(): void
+    {
+        self::assertSame('one two three', $this->htmlToText('one two three'));
+        self::assertSame(3, $this->countWords('one two three'));
+        self::assertSame('spaced out', $this->htmlToText("  spaced   out  "));
+    }
+}

--- a/tests/unit/ReadTimeHtmlStrippingTest.php
+++ b/tests/unit/ReadTimeHtmlStrippingTest.php
@@ -8,115 +8,47 @@
 
 declare(strict_types=1);
 
-namespace jalendport\readtime\tests\unit;
-
-use jalendport\readtime\services\ReadTime;
-use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
-
 /**
  * Unit coverage for the HTML-stripping behaviour added to the word counter.
  *
- * The counting helpers are private, so they're exercised through reflection.
- * `htmlToText()` is pure string-cleaning (no Craft application needed), and
- * `countWords()` only delegates to `craft\helpers\StringHelper`, so neither
- * requires a booted Craft instance.
+ * `htmlToText()` and `countWords()` are private on the service and are reached
+ * through the reflection helpers defined in tests/Pest.php.
  */
-final class ReadTimeHtmlStrippingTest extends TestCase
-{
-    private ReadTime $service;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        $this->service = new ReadTime();
-    }
+it('replaces tags with whitespace so words across a tag boundary are not merged', function () {
+    expect(htmlToText('<p>foo</p><p>bar</p>'))->toBe('foo bar');
+    expect(countWords('<p>foo</p><p>bar</p>'))->toBe(2);
+});
 
-    private function htmlToText(string $text): string
-    {
-        $method = new ReflectionMethod(ReadTime::class, 'htmlToText');
-        $method->setAccessible(true);
+it('excludes tag names, attribute names and attribute values such as URLs', function () {
+    $html = '<a class="link" href="https://example.com/some/page">Read more</a>';
 
-        return $method->invoke($this->service, $text);
-    }
+    expect(htmlToText($html))->toBe('Read more');
+    expect(countWords($html))->toBe(2);
+});
 
-    private function countWords(mixed $value): int
-    {
-        $method = new ReflectionMethod(ReadTime::class, 'countWords');
-        $method->setAccessible(true);
+it('strips nested inline markup without dropping content', function () {
+    $html = '<p>Hello <strong>brave</strong> <em>new</em> world</p>';
 
-        return $method->invoke($this->service, $value);
-    }
+    expect(htmlToText($html))->toBe('Hello brave new world');
+    expect(countWords($html))->toBe(4);
+});
 
-    /**
-     * Tags are replaced with whitespace, not removed, so words on either side of
-     * a tag boundary are not merged.
-     */
-    public function testTagsBecomeWhitespaceAndDoNotMergeWords(): void
-    {
-        self::assertSame('foo bar', $this->htmlToText('<p>foo</p><p>bar</p>'));
-        self::assertSame(2, $this->countWords('<p>foo</p><p>bar</p>'));
-    }
+it('decodes entities after tags are stripped, so &amp; is not counted as a word', function () {
+    expect(htmlToText('Salt &amp; Pepper'))->toBe('Salt & Pepper');
+});
 
-    /**
-     * Tag names, attribute names and attribute values (such as URLs) are all
-     * excluded from the cleaned text.
-     */
-    public function testTagAndAttributeTextIsExcluded(): void
-    {
-        $html = '<a class="link" href="https://example.com/some/page">Read more</a>';
+it('treats &nbsp; as whitespace so the words it separates are counted independently', function () {
+    expect(htmlToText('foo&nbsp;bar'))->toBe('foo bar');
+    expect(countWords('foo&nbsp;bar'))->toBe(2);
+});
 
-        self::assertSame('Read more', $this->htmlToText($html));
-        self::assertSame(2, $this->countWords($html));
-    }
+it('does not treat encoded angle brackets as tags', function () {
+    expect(htmlToText('a &lt;b&gt; c'))->toBe('a <b> c');
+});
 
-    /**
-     * Nested inline markup is stripped without dropping content.
-     */
-    public function testNestedInlineMarkupIsStripped(): void
-    {
-        $html = '<p>Hello <strong>brave</strong> <em>new</em> world</p>';
-
-        self::assertSame('Hello brave new world', $this->htmlToText($html));
-        self::assertSame(4, $this->countWords($html));
-    }
-
-    /**
-     * Entities are decoded after tags are stripped: `&amp;` becomes a literal
-     * `&` rather than being counted as a word.
-     */
-    public function testHtmlEntitiesAreDecoded(): void
-    {
-        self::assertSame('Salt & Pepper', $this->htmlToText('Salt &amp; Pepper'));
-    }
-
-    /**
-     * `&nbsp;` decodes to a non-breaking space and is treated as whitespace, so
-     * the words it separates are counted independently.
-     */
-    public function testNonBreakingSpaceIsTreatedAsWhitespace(): void
-    {
-        self::assertSame('foo bar', $this->htmlToText('foo&nbsp;bar'));
-        self::assertSame(2, $this->countWords('foo&nbsp;bar'));
-    }
-
-    /**
-     * Tags are stripped before entities are decoded, so text legitimately
-     * encoded as `&lt;`/`&gt;` is preserved rather than mistaken for a tag.
-     */
-    public function testEncodedAnglesAreNotTreatedAsTags(): void
-    {
-        self::assertSame('a <b> c', $this->htmlToText('a &lt;b&gt; c'));
-    }
-
-    /**
-     * Plain (non-HTML) text is unchanged apart from whitespace normalisation, so
-     * its word count is unaffected by the stripping.
-     */
-    public function testPlainTextIsUnchanged(): void
-    {
-        self::assertSame('one two three', $this->htmlToText('one two three'));
-        self::assertSame(3, $this->countWords('one two three'));
-        self::assertSame('spaced out', $this->htmlToText("  spaced   out  "));
-    }
-}
+it('leaves plain text unchanged apart from whitespace normalisation', function () {
+    expect(htmlToText('one two three'))->toBe('one two three');
+    expect(countWords('one two three'))->toBe(3);
+    expect(htmlToText('  spaced   out  '))->toBe('spaced out');
+});


### PR DESCRIPTION
## Summary

Fixes #14 — read-time counts were inflated for rich-text/HTML content because markup was fed straight into the word counter, so tag names (`p`, `strong`, `a`), attribute names (`href`, `class`), and attribute values such as URLs all got counted as "words."

The fix strips HTML centrally in the word counter (`ReadTime::countWords()`), so **both** counting paths are corrected at once:

- `entry.body | readTime` — the filter on a raw rich-text string.
- `readTime(entry)` — the field-walk over rich-text fields (CKEditor, Vizy, etc.), where the user never touches the raw string.

## Behaviour

A new `htmlToText()` helper cleans the string before counting:

- **Tags → whitespace, not removed.** `<p>foo</p><p>bar</p>` becomes `foo bar` (2 words), not `foobar` (1). Trading over-counting for under-counting would just be a different wrong answer.
- **Entities decoded after stripping.** Order matters: tags are stripped first, then `html_entity_decode()` runs, so text legitimately encoded as `&lt;`/`&gt;` isn't mistaken for a tag. `&amp;` is no longer counted as a word and `&nbsp;` becomes whitespace.
- **Unicode whitespace collapsed.** `&nbsp;` decodes to a non-breaking space (U+00A0); the `(*UCP)` verb makes `\s` match Unicode whitespace so it's treated as a separator.
- **Plain text is unchanged** apart from whitespace trimming, so non-HTML counts are unaffected.

## Tests

Adds `tests/unit/ReadTimeHtmlStrippingTest.php` (Pest) covering tag-boundary preservation, attribute/URL exclusion, entity decoding, `&nbsp;`, encoded angle brackets, and plain-text passthrough. The repo had no test harness, so this PR also wires up a minimal one: `pestphp/pest` as the dev dependency, `phpunit.xml.dist`, a `tests/Pest.php` bootstrap (which holds the reflection helpers for the private `htmlToText()`/`countWords()`), and a `composer test` script that runs Pest. Tests are written in Pest style with `it()` closures — no `TestCase` class extension. Run with `composer install && composer test`.

## Changelog / version

- `CHANGELOG.md`: change recorded under `## Unreleased`.
- `composer.json` version unchanged (`3.0.0`) — versioning/tagging/release is owner-driven.

## Notes

- Targets the Craft 5 / v3 line (`develop`); the Craft 4 line is untouched.
- No new settings or UI; field discovery/walking and the WPM math are unchanged.

Closes #14
