### PR TITLE
Add outputLocale setting to control read-time output language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- An `outputLocale` setting to control the language of the human-readable read-time string ([#20](https://github.com/jalendport/craft-readtime/issues/20)). Leave it empty to follow the current application language (unchanged default), set it to `site` to format each element in its own site's language (consistent across CP, front-end, and `resave/entries` on multi-site installs), or set a specific locale ID (e.g. `de-DE`) to force one language everywhere. Configurable in the plugin settings or via `config/read-time.php`. Only the human-readable string is affected; numeric values are unchanged.
+
 ## 3.0.0 - 2026-06-12
 
 > Craft 5 release. The 2.x line remains the Craft 4 line.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,25 @@ You can also format the duration as a [`DateInterval`](https://www.php.net/manua
 {{ time.interval('%h hours, %i minutes, %s seconds') }}  {# 0 hours, 2 minutes, 40 seconds #}
 ```
 
+### Output Locale
+
+By default the human-readable string follows the **current application language**, which depends on context: a logged-in user's preferred language in the Control Panel, the requested site's language on the front end, and the system/default language in console commands (e.g. `php craft resave/entries`). That means content pre-parsed into a custom field can end up in a different language depending on where it was saved.
+
+The `outputLocale` setting lets you pin the language of the human-readable string so it stays consistent. It is a single setting with three modes:
+
+| Value | Behaviour |
+| --- | --- |
+| _(empty)_ / `null` | **Current language** (default). The output follows the active application language — the existing behaviour, unchanged. |
+| `site` | **Content's site language.** The output is formatted in the language of the site the content belongs to. Recommended for multi-site installs: each site's content formats in its own language, including under `resave/entries`. On the `|readTime` filter (which has no element), this falls back to the current site's language. |
+| a locale ID, e.g. `de-DE` | **Force that locale everywhere.** Useful for single-site installs, or anyone who wants uniform output across all sites. |
+
+This affects **only** the human-readable string (`time` / `time.human`, and the GraphQL human-readable field). Numeric values (`time.seconds`, `time.minutes`, `time.hours`) are locale-independent and never change.
+
+In the Control Panel the dropdown lists _Current language_, _Content's site language_, and your configured site languages. Via the config file you can also set any locale ID Craft recognises, even if it isn't one of your site languages.
+
 ### Overriding Plugin Settings
 
-The average user read speed is set at 200 words per minute by default. This can be changed in the plugin settings, or overridden with a config file.
+The settings above can be changed in the plugin settings in the Control Panel, or overridden with a config file.
 
 If you create a [config file](https://craftcms.com/docs/5.x/configure.html#config-files) in your `config` folder called `read-time.php`, you can override the plugin's settings in the Control Panel. Since that config file is fully [multi-environment](https://craftcms.com/docs/5.x/configure.html#multi-environment-configs) aware, this is a handy way to have different settings across multiple environments. An example is included at [`config/read-time.php`](config/read-time.php).
 
@@ -117,6 +133,7 @@ If you create a [config file](https://craftcms.com/docs/5.x/configure.html#confi
 
 return [
     'wordsPerMinute' => 200,
+    'outputLocale' => null, // null | 'site' | a locale ID such as 'de-DE'
 ];
 ```
 

--- a/config/read-time.php
+++ b/config/read-time.php
@@ -12,4 +12,11 @@
 return [
     // The average reading speed, in words per minute.
     'wordsPerMinute' => 200,
+
+    // The locale used to format the human-readable read-time string. Use null
+    // (or omit) to follow the current application language, the 'site' keyword
+    // to format each element in its own site's language, or a specific locale
+    // ID (e.g. 'de-DE') to force one language everywhere. Only the
+    // human-readable string is affected; numeric values are not.
+    'outputLocale' => null,
 ];

--- a/src/ReadTime.php
+++ b/src/ReadTime.php
@@ -94,7 +94,34 @@ class ReadTime extends Plugin
             [
                 'settings' => $settings,
                 'overrides' => array_keys($overrides),
+                'outputLocaleOptions' => $this->outputLocaleOptions(),
             ]
         );
+    }
+
+    /**
+     * Builds the option list for the "Output Locale" dropdown: a blank
+     * "Current language" entry, the "Content's site language" keyword, then one
+     * option per configured site language. A power user can still pin an
+     * off-list locale via `config/read-time.php`; the model validates against
+     * Craft's full known-locale list.
+     *
+     * @return array<int, array{label: string, value: string}>
+     */
+    private function outputLocaleOptions(): array
+    {
+        $options = [
+            ['label' => Craft::t('read-time', 'Current language'), 'value' => ''],
+            ['label' => Craft::t('read-time', 'Content’s site language'), 'value' => Settings::OUTPUT_LOCALE_SITE],
+        ];
+
+        foreach (Craft::$app->getI18n()->getSiteLocales() as $locale) {
+            $options[] = [
+                'label' => $locale->getDisplayName(Craft::$app->language) . ' (' . $locale->id . ')',
+                'value' => $locale->id,
+            ];
+        }
+
+        return $options;
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -12,20 +12,66 @@ declare(strict_types=1);
 
 namespace jalendport\readtime\models;
 
+use Craft;
 use craft\base\Model;
 
 class Settings extends Model
 {
     /**
+     * The reserved keyword that pins the human-readable output to the language
+     * of the site the content belongs to.
+     */
+    public const OUTPUT_LOCALE_SITE = 'site';
+
+    /**
      * @var int Average reading speed, in words per minute.
      */
     public int $wordsPerMinute = 200;
+
+    /**
+     * @var string|null The locale used to format the human-readable read-time
+     * string. Encodes three modes:
+     *
+     * - `null` / empty → "Current language": the output follows
+     *   `Craft::$app->language` (the historical behaviour).
+     * - `'site'` → "Content's site language": the output is formatted in the
+     *   language of the site the content belongs to.
+     * - a specific locale ID (e.g. `'de-DE'`) → that locale is forced
+     *   everywhere.
+     *
+     * Only the human-readable string is affected; numeric outputs are
+     * locale-independent.
+     */
+    public ?string $outputLocale = null;
 
     public function rules(): array
     {
         return [
             [['wordsPerMinute'], 'required'],
             [['wordsPerMinute'], 'number', 'integerOnly' => true],
+            [['outputLocale'], 'validateOutputLocale'],
         ];
+    }
+
+    /**
+     * Allows `null`/empty, the literal `'site'` keyword, or any locale ID that
+     * Craft knows about. Validating against the full known-locale list (rather
+     * than just the install's site languages) lets a power user pin an
+     * off-list locale via `config/read-time.php` even though the CP dropdown
+     * only lists configured site languages.
+     */
+    public function validateOutputLocale(string $attribute): void
+    {
+        $value = $this->$attribute;
+
+        if ($value === null || $value === '' || $value === self::OUTPUT_LOCALE_SITE) {
+            return;
+        }
+
+        if (!in_array($value, Craft::$app->getI18n()->getAllLocaleIds(), true)) {
+            $this->addError($attribute, Craft::t('read-time', 'Output Locale must be empty, “{site}”, or a valid locale ID.', [
+                'site' => self::OUTPUT_LOCALE_SITE,
+            ]));
+        }
     }
 }

--- a/src/models/TimeModel.php
+++ b/src/models/TimeModel.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace jalendport\readtime\models;
 
+use Craft;
 use craft\base\Model;
 use craft\helpers\DateTimeHelper;
 use Exception;
@@ -28,6 +29,17 @@ class TimeModel extends Model
      */
     public bool $showSeconds = true;
 
+    /**
+     * @var string|null The concrete locale to format the human-readable
+     * duration in, or `null` to follow the current application language.
+     *
+     * This is always a resolved locale ID (never the `'site'` keyword): the
+     * {@see \jalendport\readtime\services\ReadTime} service resolves the
+     * configured mode against the element/site before building the model, so
+     * this value object stays free of element or settings logic.
+     */
+    public ?string $outputLocale = null;
+
     public function __toString(): string
     {
         return $this->human();
@@ -35,7 +47,24 @@ class TimeModel extends Model
 
     public function human(): string
     {
-        return DateTimeHelper::humanDuration($this->seconds, $this->showSeconds);
+        if ($this->outputLocale === null) {
+            return DateTimeHelper::humanDuration($this->seconds, $this->showSeconds);
+        }
+
+        // DateTimeHelper::humanDuration() takes no locale argument — it formats
+        // using Craft::$app->language. Temporarily swap the application language
+        // to the resolved locale around the call so the wording is translated
+        // consistently regardless of context (CP request, front-end, or a
+        // `php craft resave/entries` console run), then always restore it.
+        $app = Craft::$app;
+        $originalLanguage = $app->language;
+        $app->language = $this->outputLocale;
+
+        try {
+            return DateTimeHelper::humanDuration($this->seconds, $this->showSeconds);
+        } finally {
+            $app->language = $originalLanguage;
+        }
     }
 
     /**

--- a/src/services/ReadTime.php
+++ b/src/services/ReadTime.php
@@ -24,6 +24,7 @@ use jalendport\readtime\fieldhandlers\CkeditorHandler;
 use jalendport\readtime\fieldhandlers\MatrixHandler;
 use jalendport\readtime\fieldhandlers\NeoHandler;
 use jalendport\readtime\fieldhandlers\VizyHandler;
+use jalendport\readtime\models\Settings;
 use jalendport\readtime\models\TimeModel;
 use jalendport\readtime\ReadTime as ReadTimePlugin;
 use Throwable;
@@ -64,9 +65,14 @@ class ReadTime extends Component
      */
     public function calculateForElement(mixed $element, bool $showSeconds = true): TimeModel
     {
+        // Resolve the output-locale mode against the element when we have one,
+        // so 'site' mode picks up that element's site language.
+        $context = $element instanceof ElementInterface ? $element : null;
+
         return new TimeModel([
             'seconds' => $this->secondsForValue($element),
             'showSeconds' => $showSeconds,
+            'outputLocale' => $this->resolveOutputLocale($context),
         ]);
     }
 
@@ -76,9 +82,12 @@ class ReadTime extends Component
      */
     public function calculateForValue(mixed $value, bool $showSeconds = true): TimeModel
     {
+        // The filter path has no element; 'site' mode falls back to the current
+        // site's language inside resolveOutputLocale().
         return new TimeModel([
             'seconds' => $this->secondsForString($value),
             'showSeconds' => $showSeconds,
+            'outputLocale' => $this->resolveOutputLocale(null),
         ]);
     }
 
@@ -162,6 +171,36 @@ class ReadTime extends Component
 
     // Private Methods
     // =========================================================================
+
+    /**
+     * Resolves the configured `outputLocale` mode to a concrete locale ID (or
+     * `null`) for the model. Keeping this in the service means {@see TimeModel}
+     * never sees the `'site'` keyword, the settings, or the element.
+     *
+     * - empty/null → `null` (the model follows the current application language).
+     * - `'site'` → the element's site language, or — on the element-less filter
+     *   path — the current site's language (preserving the "a site's language"
+     *   semantic rather than falling back to the CP user's language).
+     * - a specific locale ID → that locale, verbatim.
+     */
+    private function resolveOutputLocale(?ElementInterface $element): ?string
+    {
+        $mode = ReadTimePlugin::getInstance()->getSettings()->outputLocale;
+
+        if ($mode === null || $mode === '') {
+            return null;
+        }
+
+        if ($mode === Settings::OUTPUT_LOCALE_SITE) {
+            if ($element !== null) {
+                return $element->getSite()->language;
+            }
+
+            return Craft::$app->getSites()->getCurrentSite()->language;
+        }
+
+        return $mode;
+    }
 
     private function secondsForValue(mixed $element): int
     {

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -22,3 +22,14 @@
     disabled:     'wordsPerMinute' in overrides,
     warning:      'wordsPerMinute' in overrides ? configWarning('wordsPerMinute'),
 }) }}
+
+{{ forms.selectField({
+    label:        'Output Locale',
+    instructions: 'The language used for the human-readable read-time string (e.g. “2 minutes” vs “2 Minuten”). “Current language” keeps the existing behaviour (the output follows the active CP, site, or console language). “Content’s site language” formats each element in the language of the site it belongs to — recommended for multi-site installs. Choosing a specific language forces it everywhere. This only affects the human-readable string; numeric values are unaffected.',
+    id:           'outputLocale',
+    name:         'outputLocale',
+    options:      outputLocaleOptions,
+    value:        settings.outputLocale,
+    disabled:     'outputLocale' in overrides,
+    warning:      'outputLocale' in overrides ? configWarning('outputLocale'),
+}) }}


### PR DESCRIPTION
## Summary

Adds an `outputLocale` setting that lets users control the language used for the human-readable read-time string, so it stays consistent regardless of context (CP request, front-end, or `php craft resave/entries`). Closes #20.

Today the human-readable output follows `Craft::$app->language`, which differs by context: the CP user's language in the control panel, the requested site's language on the front end, and the system/default language under console commands — so a read-time string pre-parsed into a custom field can render in German in the CP but English when re-saved from the console.

## Behavior — a single setting, three modes

`outputLocale` is a nullable string on the `Settings` model, defaulting to `null`:

- **empty / `null` → "Current language" (default).** Preserves today's exact behaviour (output follows the active application language). Strictly opt-in; existing sites are unchanged on upgrade.
- **`'site'` → "Content's site language".** Formatted in the language of the site the content belongs to (`$element->getSite()->language`). The multi-site-correct option: each site's content formats in its own language, including under `resave/entries`. On the element-less `|readTime` filter path, falls back to the current site's language (`getCurrentSite()->language`).
- **a specific locale ID (e.g. `'de-DE'`) → force that locale everywhere.**

This affects **only** the human-readable string (`TimeModel::human()` / `__toString()`). Numeric outputs (`seconds()`, `minutes()`, `hours()`) are locale-independent and unchanged.

## Implementation

- **Mode → locale resolution lives in the service** (`services/ReadTime::resolveOutputLocale()`), where both the element and the settings are available. `TimeModel` only ever holds a resolved concrete locale (or `null`) and stays a plain value object — it never sees the `'site'` keyword or the element.
- **Forced locale in `TimeModel::human()`:** `DateTimeHelper::humanDuration()` takes no locale argument and formats using `Craft::$app->language`, so when `outputLocale` is set we temporarily swap `Craft::$app->language` around the call and **always restore it in a `finally` block** (even on exception). This reuses Craft's own translated duration wording verbatim.
- **Settings model & CP UI:** new `outputLocale` property + an "Output Locale" dropdown in `settings.twig` ([Current language] + [Content's site language] + configured site languages), with config-file override support (auto-disable + warning). Validation allows `null`, the literal `'site'`, or any locale ID Craft knows about (so a power user can pin an off-list locale via `config/read-time.php`).
- **Docs & release:** documented in the README; recorded under `## Unreleased` in `CHANGELOG.md`. The `composer.json` version is intentionally **not** bumped (versioning/releases handled separately).

## Notes / verification

- This is the Craft 5 / v3 (service-based) line; branched from and targeting `develop`. No changes to word-counting logic or numeric outputs.
- **GraphQL:** there is no GraphQL type in this codebase, so no GraphQL code change was needed; the human-readable field maps to `human()` and would therefore reflect the resolved locale automatically.
- This repo has no PHP toolchain or test harness checked in (and no PR CI workflow on this line), so I could not run a unit test or `php -l` here. The change was verified by close manual review against the Craft 5 API (`getI18n()->getAllLocaleIds()` / `getSiteLocales()`, `Element::getSite()->language`, `Sites::getCurrentSite()`, and the `Craft::$app->language` swap that drives `DateTimeHelper::humanDuration()`). A follow-up to add a test harness would be worthwhile — flagging for the maintainer.
